### PR TITLE
Mody ADC_GetConversionValue return data

### DIFF
--- a/Libraries/W7500x_StdPeriph_Driver/src/w7500x_adc.c
+++ b/Libraries/W7500x_StdPeriph_Driver/src/w7500x_adc.c
@@ -110,10 +110,12 @@ void ADC_StartOfConversion(void)
  */
 uint16_t ADC_GetConversionValue(void)
 {
+    uint16_t ret=0;
     if (adc_conversion_start == SET) {
         adc_conversion_start = RESET;
-        return (uint16_t) ADC->DATA;
+        ret=  ADC->DATA;
     }
+    return ret;
 }
 
 /**


### PR DESCRIPTION
The original `ADC_GetConversionValue` function had a return statement defined only within an if statement,
 leading to a warning because an unspecified value would be returned if the if statement did not execute. 

This update modifies the code to ensure a return value of `0` when the if statement does not execute, addressing the issue of returning an undefined value.